### PR TITLE
Update logo_path

### DIFF
--- a/config.py
+++ b/config.py
@@ -22,31 +22,31 @@ NETWORKS = [
         "name": "osmosis",
         "lcd_api": "https://lcd.osmosis-1.bronbro.io",
         "prefix": "osmo",
-        "logo_path": "https://raw.githubusercontent.com/cosmostation/cosmostation_token_resource/master/moniker/osmosis/"
+        "logo_path": "https://raw.githubusercontent.com/cosmostation/chainlist/main/chain/osmosis/moniker/"
     },
     {
         "name": "juno",
         "lcd_api": "https://lcd.juno-1.bronbro.io",
         "prefix": "juno",
-        "logo_path": "https://raw.githubusercontent.com/cosmostation/cosmostation_token_resource/master/moniker/juno/"
+        "logo_path": "https://raw.githubusercontent.com/cosmostation/chainlist/main/chain/juno/moniker/"
     },
     {
         "name": "stargaze",
         "lcd_api": "https://lcd.stargaze-1.bronbro.io",
         "prefix": "stars",
-        "logo_path": "https://raw.githubusercontent.com/cosmostation/cosmostation_token_resource/master/moniker/stargaze/"
+        "logo_path": "https://raw.githubusercontent.com/cosmostation/chainlist/main/chain/stargaze/moniker/"
     },
     {
         "name": "gravity",
         "lcd_api": "https://lcd.gravity-bridge-3.bronbro.io",
         "prefix": "gravity",
-        "logo_path": "https://raw.githubusercontent.com/cosmostation/cosmostation_token_resource/master/moniker/gravity-bridge/"
+        "logo_path": "https://raw.githubusercontent.com/cosmostation/chainlist/main/chain/gravity-bridge/moniker/"
     },
     {
         "name": "crescent",
         "lcd_api": "https://lcd.crescent-1.bronbro.io",
         "prefix": "cre",
-        "logo_path": "https://raw.githubusercontent.com/cosmostation/cosmostation_token_resource/master/moniker/crescent/"
+        "logo_path": "https://raw.githubusercontent.com/cosmostation/chainlist/main/chain/crescent/moniker/"
     },
     # {
     #     "name": "omniflix",
@@ -61,7 +61,7 @@ NETWORKS = [
         "name": "cosmoshub",
         "lcd_api": "https://lcd.cosmoshub-4.bronbro.io",
         "prefix": "cosmos",
-        "logo_path": "https://raw.githubusercontent.com/cosmostation/cosmostation_token_resource/master/moniker/cosmoshub/"
+        "logo_path": "https://raw.githubusercontent.com/cosmostation/chainlist/main/chain/cosmos/moniker/"
     },
     # {
     #     "name": "desmos",
@@ -85,7 +85,7 @@ NETWORKS = [
         "name": "stride",
         "lcd_api": "https://lcd.stride-1.bronbro.io",
         "prefix": "stride",
-        "logo_path": "https://raw.githubusercontent.com/cosmostation/cosmostation_token_resource/master/moniker/stride/"
+        "logo_path": "https://raw.githubusercontent.com/cosmostation/chainlist/main/chain/stride/moniker/"
     },
 ]
 


### PR DESCRIPTION
https://github.com/cosmostation/cosmostation_token_resource is deprecated, this PR will update the logo_path parameter to use https://github.com/cosmostation/chainlist/tree/main/chain.